### PR TITLE
Uses media-pipelines to downloads mp3 files

### DIFF
--- a/podcasts_downloader/items.py
+++ b/podcasts_downloader/items.py
@@ -6,7 +6,15 @@
 # https://doc.scrapy.org/en/latest/topics/items.html
 
 import scrapy
+from scrapy.loader.processors import MapCompose
 
 
-class PodcastsDownloaderItem(scrapy.Item):
-    file_urls = scrapy.Field()
+# absolute_url solution by Frank:
+# https://stackoverflow.com/questions/48874341/python-scrapy-get-absolute-url-using-input-processor
+
+def absolute_url(url, loader_context):
+    return loader_context['response'].urljoin(url)
+
+
+class PodcastMP3Item(scrapy.Item):
+    file_urls = scrapy.Field(input_processor=MapCompose(absolute_url))

--- a/podcasts_downloader/items.py
+++ b/podcasts_downloader/items.py
@@ -9,6 +9,4 @@ import scrapy
 
 
 class PodcastsDownloaderItem(scrapy.Item):
-    # define the fields for your item here like:
-    # name = scrapy.Field()
-    pass
+    file_urls = scrapy.Field()

--- a/podcasts_downloader/settings.py
+++ b/podcasts_downloader/settings.py
@@ -66,9 +66,12 @@ ROBOTSTXT_OBEY = True
 
 # Configure item pipelines
 # See https://doc.scrapy.org/en/latest/topics/item-pipeline.html
-#ITEM_PIPELINES = {
-#    'podcasts_downloader.pipelines.PodcastsDownloaderPipeline': 300,
-#}
+ITEM_PIPELINES = {
+    'scrapy.pipelines.files.FilesPipeline': 1,
+    # 'podcasts_downloader.pipelines.PodcastsDownloaderPipeline': 300,
+}
+
+MEDIA_ALLOW_REDIRECTS = True
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://doc.scrapy.org/en/latest/topics/autothrottle.html

--- a/podcasts_downloader/spiders/talkpython.py
+++ b/podcasts_downloader/spiders/talkpython.py
@@ -14,21 +14,10 @@ class TalkpythonSpider(scrapy.Spider):
 
         for episode_href in episode_hrefs:
             episode_url = response.urljoin(episode_href)
-            yield scrapy.Request(episode_url, callback=self.download_mp3)
+            yield scrapy.Request(episode_url, callback=self.parse_mp3_links)
 
-    def download_mp3(self, response):
+    def parse_mp3_links(self, response):
         podcast_href = response.xpath("//a[contains(@href,'.mp3')]/@href").extract_first()
         if podcast_href:
-            file_path = self.mp3_file_path(podcast_href)
-
-            if not os.path.exists(file_path):
-                podcast_url = response.urljoin(podcast_href)
-                yield scrapy.Request(podcast_url, callback=self.save_file)
-
-    def save_file(self, response):
-        file_path = self.mp3_file_path(response.url)
-        with open(file_path, 'wb') as f:
-            f.write(response.body)
-
-    def mp3_file_path(self, url):
-        return os.path.join(self.settings['FILES_STORE'], url.split('/')[-1])
+            podcast_url = response.urljoin(podcast_href)
+            yield {'file_urls': [podcast_url]}

--- a/podcasts_downloader/spiders/talkpython.py
+++ b/podcasts_downloader/spiders/talkpython.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import os
 import scrapy
-
+from scrapy.loader import ItemLoader
+from podcasts_downloader.items import PodcastMP3Item
 
 class TalkpythonSpider(scrapy.Spider):
     name = 'talkpython'
@@ -17,7 +17,6 @@ class TalkpythonSpider(scrapy.Spider):
             yield scrapy.Request(episode_url, callback=self.parse_mp3_links)
 
     def parse_mp3_links(self, response):
-        podcast_href = response.xpath("//a[contains(@href,'.mp3')]/@href").extract_first()
-        if podcast_href:
-            podcast_url = response.urljoin(podcast_href)
-            yield {'file_urls': [podcast_url]}
+        url_loader = ItemLoader(item=PodcastMP3Item(), response=response)
+        url_loader.add_xpath('file_urls', '//a[contains(@href,".mp3")]/@href')
+        return url_loader.load_item()


### PR DESCRIPTION
Main changes:
- Removed download from spider 
- Created item PodcastMP3Item
- Implemented item loaders to simplify spider parses
- Enabled native ITEM_PIPELINES scrapy.pipelines.files.FilesPipeline